### PR TITLE
Update openconfig-vlan.yang

### DIFF
--- a/release/models/vlan/openconfig-vlan.yang
+++ b/release/models/vlan/openconfig-vlan.yang
@@ -117,7 +117,28 @@ module openconfig-vlan {
   grouping vlan-state {
     description "State variables for VLANs";
 
-    // placeholder
+    leaf vlan-id {
+      type oc-vlan-types:vlan-id;
+      description "Interface VLAN id.";
+    }
+
+    leaf name {
+      type string;
+      description "Interface VLAN name.";
+    }
+
+    leaf status {
+      type enumeration {
+        enum ACTIVE {
+          description "VLAN is active";
+        }
+        enum SUSPENDED {
+          description "VLAN is inactive / suspended";
+        }
+      }
+      default ACTIVE;
+      description "Admin state of the VLAN";
+    }
 
   }
 
@@ -140,7 +161,15 @@ module openconfig-vlan {
     description
       "TPID opstate for dot1q-enabled interfaces";
 
-    // placeholder
+    leaf tpid {
+      type identityref {
+        base oc-vlan-types:TPID_TYPES;
+      }
+      default oc-vlan-types:TPID_0X8100;
+      description
+        "Optionally set the tag protocol identifier field (TPID) that
+        is accepted on the VLAN";
+    }
 
   }
 


### PR DESCRIPTION
Removed placeholders in "vlan-state" and "vlan-tpid-state" with the associated leaves.